### PR TITLE
Fix typing issues for cythonization

### DIFF
--- a/nemo_text_processing/text_normalization/normalize.py
+++ b/nemo_text_processing/text_normalization/normalize.py
@@ -247,7 +247,7 @@ class Normalizer:
         return normalized_texts
 
     def _estimate_number_of_permutations_in_nested_dict(
-        self, token_group: Dict[str, Union[OrderedDict, str, bool]]
+        self, token_group: OrderedDict[str, Union[OrderedDict, str, bool]]
     ) -> int:
         num_perms = 1
         for k, inner in token_group.items():
@@ -256,7 +256,7 @@ class Normalizer:
         num_perms *= factorial(len(token_group))
         return num_perms
 
-    def _split_tokens_to_reduce_number_of_permutations(self, tokens: List[dict]) -> List[List[dict]]:
+    def _split_tokens_to_reduce_number_of_permutations(self, tokens: List[OrderedDict]) -> List[List[OrderedDict]]:
         """
         Splits a sequence of tokens in a smaller sequences of tokens in a way that maximum number of composite
         tokens permutations does not exceed ``max_number_of_permutations_per_split``.
@@ -343,9 +343,9 @@ class Normalizer:
         logger.debug(tagged_text)
 
         self.parser(tagged_text)
-        tokens = self.parser.parse()
-        self.tokens = tokens
-        split_tokens = self._split_tokens_to_reduce_number_of_permutations(tokens)
+        tokens: List[OrderedDict] = self.parser.parse()
+        self.tokens: List[OrderedDict] = tokens
+        split_tokens: List[List[OrderedDict]] = self._split_tokens_to_reduce_number_of_permutations(tokens)
         output = ""
         for s in split_tokens:
             try:
@@ -581,7 +581,7 @@ class Normalizer:
             l.extend(subl)
         return l
 
-    def generate_permutations(self, tokens: List[dict]):
+    def generate_permutations(self, tokens: List[OrderedDict]):
         """
         Generates permutations of string serializations of list of dictionaries
 
@@ -591,7 +591,7 @@ class Normalizer:
         Returns string serialization of list of dictionaries
         """
 
-        def _helper(prefix: str, token_list: List[dict], idx: int):
+        def _helper(prefix: str, token_list: List[OrderedDict], idx: int):
             """
             Generates permutations of string serializations of given dictionary
 

--- a/nemo_text_processing/text_normalization/token_parser.py
+++ b/nemo_text_processing/text_normalization/token_parser.py
@@ -41,7 +41,7 @@ class TokenParser:
         self.char = text[0]  # cannot handle empty string
         self.index = 0
 
-    def parse(self) -> List[dict]:
+    def parse(self) -> List[OrderedDict]:
         """
         Main function. Implements grammar:
         A -> space F space F space F ... space
@@ -56,7 +56,7 @@ class TokenParser:
             l.append(token)
         return l
 
-    def parse_token(self) -> Dict[str, Union[str, dict]]:
+    def parse_token(self) -> OrderedDict[str, Union[str, OrderedDict]]:
         """
         Implements grammar:
         F-> no_space KG no_space
@@ -78,7 +78,7 @@ class TokenParser:
         d[key] = value
         return d
 
-    def parse_token_value(self) -> Union[str, dict]:
+    def parse_token_value(self) -> Union[str, OrderedDict]:
         """
         Implements grammar:
         G-> no_space :"VALUE" no_space | no_space {A} no_space


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Have you signed your commits? Use ``git commit -s`` to sign.
- [ ] Do all unittests finish successfully before sending PR?
   1) ``pytest`` or (if your machine does not have GPU) ``pytest --cpu`` from the root folder (given you marked your test cases accordingly `@pytest.mark.run_only_on('CPU')`).
   2) Sparrowhawk tests ``bash tools/text_processing_deployment/export_grammars.sh --MODE=test ...``
- [ ] If you are adding a new feature: Have you added test cases for both `pytest` and Sparrowhawk [here](tests/nemo_text_processing).
- [ ] Have you added ``__init__.py`` for every folder and subfolder, including `data` folder which has .TSV files?
- [ ] Have you followed codeQL results and removed unused variables and imports (report is at the bottom of the PR in github review box) ?
- [ ] Have you added the correct license header `Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.` to all newly added Python files?
- [ ] If you copied [nemo_text_processing/text_normalization/en/graph_utils.py](nemo_text_processing/text_normalization/en/graph_utils.py) your header's second line should be `Copyright 2015 and onwards Google, Inc.`. See an example [here](https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/graph_utils.py#L2).
- [ ] Remove import guards (`try import: ... except: ...`) if not already done.
- [ ] If you added a new language or a new feature please update the [NeMo documentation](https://github.com/NVIDIA/NeMo/blob/main/docs/source/nlp/text_normalization/wfst/wfst_text_normalization.rst) (lives in different repo).
- [ ] Have you added your language support to [tools/text_processing_deployment/pynini_export.py](tools/text_processing_deployment/pynini_export.py).
  


**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
- [ ] Test

If you haven't finished some of the above items you can still open "Draft" PR.
